### PR TITLE
Keep operations w/ scalar-type returns

### DIFF
--- a/src/utils/queryGenerator.ts
+++ b/src/utils/queryGenerator.ts
@@ -104,7 +104,7 @@ function generateOperationNode(
   const operationFields = selectFieldsRecursive(doc, field, maxDepth)
   const selectionSet = operationFields.selectionSet?.selections
   // If node has no selections generated, don't print this node at all
-  if (!selectionSet?.length) return
+  if (!selectionSet?.length && !isScalar(doc, field.getType())) return
 
   const query = t.operation({
     operation: operation,


### PR DESCRIPTION
Right now, any mutations or queries defined with a scalar return type will be omitted from the generated operations. This patch allows these to be generated.

e.g.
```GraphQL
type mutation {
  deleteEntity(entityId: ID!): Boolean
}
```
should compile to:

```GraphQL
mutation deleteEntity($entityId: ID!) {
  deleteEntity(entityId: $entityId)
}
```